### PR TITLE
GH_REPO added to env

### DIFF
--- a/.github/workflows/short-titles.yml
+++ b/.github/workflows/short-titles.yml
@@ -44,4 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.issue.number }} # For issues
+          LABELS: ${{ secrets.REPO_TEAM }}
+          GH_REPO: ${{ github.repository }}
+          PROJECT: ${{ secrets.ASSIGN_PROJECT }}
           # NUMBER: ${{ github.event.pull_request.number }} # For pull requests


### PR DESCRIPTION
GH_REPO added to env due to resolve "failed to run git: fatal: not a git repository (or any of the parent directories): .git " err